### PR TITLE
removed Shelley references

### DIFF
--- a/stake-pool-guide/getting-started/cli.md
+++ b/stake-pool-guide/getting-started/cli.md
@@ -10,28 +10,22 @@ We can get the top level help by simply typing the command without arguments:
 cardano-cli
 ```
 
-We will be told that one available subcommand is `shelley`, and typing
+We will be told that one available subcommand is `node`, and typing
 
 ```text
-cardano-cli shelley
+cardano-cli node
 ```
 
-will display available sub-subcommands, one of which is `node`. We can continue drilling down the hierarchy:
+will display available sub-subcommands, one of which is `key-gen`. Typing
 
 ```text
-cardano-cli shelley node
-```
-
-and learn about the sub-sub-subcommand `key-gen`. Typing
-
-```text
-cardano-cli shelley node key-gen
+cardano-cli node key-gen
 ```
 
 will inform us about the parameters this command takes, so we can for example generate a key-pair of offline keys and a file for the issue counter by typing
 
 ```text
-cardano-cli shelley node key-gen \
+cardano-cli node key-gen \
 --cold-verification-key-file cold.vkey \
 --cold-signing-key-file cold.skey \
 --operational-certificate-issue-counter-file cold.counter


### PR DESCRIPTION
The infographic at the bottom will need amending too. Does anyone have access to the original file? Was it vector?

Also, should there be a note showing what happens if you do run the command with shelley subcommand? This still works, but will soon be removed. 

Looking forward to your thoughts,

A