### PR TITLE
cabal clean and update

### DIFF
--- a/stake-pool-guide/getting-started/install-node.md
+++ b/stake-pool-guide/getting-started/install-node.md
@@ -162,6 +162,8 @@ git checkout tags/1.24.2
 Now we build and install the node with `cabal`, which will take a few minutes the first time you do a build. Later builds will be much faster, because everything that does not change will be cached.
 
 ```text
+cabal clean
+cabal update
 cabal build all
 ```
 


### PR DESCRIPTION
Hey team,

### Description of Problem
I was following instructions at [docs.cardano.org](https://docs.cardano.org/projects/cardano-node/en/latest/getting-started/install.html) for how to build from source and started running into errors.

#### The error
Here was my [original forum post](https://forum.cardano.org/t/cabal-install-executables-missing/44923) with the **error output** I was running into, when I only ran `cabal update` once

### Suggested Solution
I found users in several forum issues ([issue1](https://forum.cardano.org/t/cabal-seems-to-not-build/39528/13), [forum2](https://forum.cardano.org/t/setting-up-cardano-node-shelly-on-centos-8/38065), [forum3](https://forum.cardano.org/t/cli-1-18-1-error-could-not-find-module-shelley-spec-ledger-bench-gen/38307/2)) suggesting `cabal clean` and `cabal update` for various cabal build problems. So I tried it and it worked.

### Tested Solution (success)
```
cabal clean
cabal update
cabal build all
```
### Note
Note - there is already a `cabal update` in the tutorials, but you need to run it again right before you do `cabal build all`, you'll find that it does additional things that were not performed the first time you ran `cabal update` (not sure what changes in between, maybe something changed from running cabal configure with compiler?). I believe it's putting more directories into `dist-newstyle/build/x86_64-linux/ghc-8.10.2/`, which are lacking if you don't run the second `cabal update` (see my forum post linked below).

What do you think? Could this be related? Or maybe was some other human error I was making. I'm not familiar with cabal. I know we're looking for community support with improving the docs so this is my attempt.

