### PR TITLE
Config Protocol Cardano

### DIFF
--- a/stake-pool-guide/getting-started/understanding-config-files.md
+++ b/stake-pool-guide/getting-started/understanding-config-files.md
@@ -149,11 +149,11 @@ This file has **4** sections that allow you to have full control on what your no
 
 ### 1 Basic Node Configuration.
 
-The first section relates to the basic node configuration parameters. Make sure you have to `TPraos`as the protocol, the correct path to the `testnet-shelley-genesis.json` file, `RequiresMagic`for its use in a testnet. Note that in this example we are using the SimpleView. This will send the output to `stdout`. The other option is `LiveView` which uses a terminal multiplexer to generate a fancy view. We will cover this topic later.
+The first section relates to the basic node configuration parameters. Make sure you have to `Cardano`as the protocol, the correct path to the `testnet-shelley-genesis.json` file, `RequiresMagic`for its use in a testnet. Note that in this example we are using the SimpleView. This will send the output to `stdout`. The other option is `LiveView` which uses a terminal multiplexer to generate a fancy view. We will cover this topic later.
 
 ```text
 {
-  "Protocol": "TPraos",
+  "Protocol": "Cardano",
   "GenesisFile": "testnet-shelley-genesis.json",
   "RequiresNetworkMagic": "RequiresMagic",
 ```


### PR DESCRIPTION
### How to Reproduce
- follow instructions for stake pool course, Build from Source
- `testnet-config.json` w/ `"Protocol": "Tpraos"`
- run
```
cardano-node run \
 --topology testnet-topology.json \
 --database-path db \
 --socket-path db/node.socket \
 --host-addr 0.0.0.0 \
 --port 3001 \
 --config testnet-config.json
```

#### Error output
I posted about it here https://forum.cardano.org/t/host-addr-0-0-0-0-causes-errorpolicysuspendconsumer-application-exception/44987 then found if i change the config's Protocol from 'Tpraos' to 'Cardano', then it works.

### Solution
`testnet-config.json` w/ `"Protocol": "Cardano"`

### Discussion
- https://forum.cardano.org/t/basic-node-configuration-why-the-tpraos-protocol/37714
- this user had same error output I posted about, and suggestions for 'Cardano' fixed it: https://forum.cardano.org/t/problems-with-running-node-1-20-0-on-testnet/40625/2
- If things in are moving in the direction of 'Tpraos', then maybe put 'Cardano' in docs for now and add a comment, "This will get updated to TPraos in the future"? Or, just leave it as 'Cardano' for now, which I vote for, if this is really the only way it will work. Note - this is testnet I'm doing, not sure if mainnet is different.