### PR TITLE
Updated Handbook to Fix Versions

### DIFF
--- a/stake-pool-guide/getting-started/install-node.md
+++ b/stake-pool-guide/getting-started/install-node.md
@@ -123,7 +123,7 @@ cd ghc-8.10.2
 sudo make install
 cd ..
 ```
-Alternatively, the ghcup tool can be used to install and set several versions of GHC: 
+Alternatively, the ghcup tool can be used to install and set several versions of GHC:
 
 ```text
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
@@ -176,12 +176,12 @@ We change our working directory to the downloaded source code folder:
 cd cardano-node
 ```
 
-For reproducible builds, we should check out a specific release, a specific "tag". For the Shelley Testnet, we will use tag `1.24.2`, which we can check out as follows:
+For reproducible builds, we should check out a specific release, a specific "tag". For the Mary Testnet, we will use tag `1.25.1`, which we can check out as follows:
 
 ```text
 git fetch --all --tags
 git tag
-git checkout tags/1.24.2
+git checkout tags/1.25.1
 ```
 
 ## Build and install the node
@@ -238,7 +238,6 @@ _Note:_ It might be necessary to delete the `db`-folder \(the database-folder\) 
 
 {% hint style="info" %}
 QUESTIONS AND FEEDBACK
-  
+
 If you have any questions and suggestions while taking the lessons please feel free to ask in the [forum](https://forum.cardano.org/c/staking-delegation/setup-a-stake-pool/158) and we will respond as soon as possible.
 {% endhint %}
-

--- a/stake-pool-guide/stake-pool-operations/keys_and_addresses.md
+++ b/stake-pool-guide/stake-pool-operations/keys_and_addresses.md
@@ -65,7 +65,7 @@ make sure that your node is running. Then use `cardano-cli shelley query utxo` t
 
 ```text
 cardano-cli query utxo \
---allegra-era \
+--mary-era \
 --address $(cat payment.addr) \
 --testnet-magic 1097911063
 ```
@@ -84,4 +84,3 @@ QUESTIONS AND FEEDBACK
 
 If you have any questions and suggestions while taking the lessons please feel free to ask in the [forum](https://forum.cardano.org/c/english/operators-talk/119) and we will respond as soon as possible.
 {% endhint %}
-


### PR DESCRIPTION
I started going through this tutorial yesterday, but found that using `1.24.2` caused issues later due to incompatibility with Mary. This is just a few quick fixes that make it work as expected, without having to upgrade the verison, delete the database folder and start over.