### PR TITLE
Update deposit protocol parameter name

### DIFF
--- a/stake-pool-guide/stake-key/register_key.md
+++ b/stake-pool-guide/stake-key/register_key.md
@@ -54,11 +54,11 @@ cardano-cli transaction calculate-min-fee \
 
 In this transaction we have to not only pay transaction fees, but also include a _deposit_ \(which we will get back when we deregister the key\) as stated in the protocol parameters:
 
-The deposit amount can be found in the `protocol.json` under `keyDeposit`:
+The deposit amount can be found in the `protocol.json` under `stakeAddressDeposit`:
 
 ```text
     ...
-    "keyDeposit": 2000000,
+    "stakeAddressDeposit": 2000000,
     ...
 ```
 


### PR DESCRIPTION
Found in the [**Register stake address in the blockchain**](https://cardano-foundation.gitbook.io/stake-pool-course/stake-pool-guide/stake-key/register_key) article.

Presumably `keyDeposit` has been deprecated. This change updates the article to use `stakeAddressDeposit`, the current parameter found in the `protocol-parameters`.