### PR TITLE
Adds steps to add needed libsodium paths

### DIFF
--- a/stake-pool-guide/getting-started/install-node.md
+++ b/stake-pool-guide/getting-started/install-node.md
@@ -154,6 +154,14 @@ make
 sudo make install
 
 ```
+  
+Add the following to your .bashrc file and source it.
+
+```text
+export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
+  
 
 ## Download the source code for cardano-node
 


### PR DESCRIPTION
Adds a simple section to modify bashrc file to include necessary paths for libsodium installation. Based on this reference: https://github.com/input-output-hk/cardano-node/blob/231a67eb21679661c66be60d1460bf41feb06b40/doc/getting-started/install.md